### PR TITLE
Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,28 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, opened, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  status: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || contains(github.head_ref, 'auto-merge')
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.16.2"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: ""
+          MERGE_METHOD: "squash"
+          MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
+          MERGE_FORKS: "false"
+          MERGE_RETRIES: "6"
+          MERGE_RETRY_SLEEP: "10000"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automatic PR merging
- Auto-merge dependabot PRs when CI passes
- Auto-merge branches with 'auto-merge' prefix
- Uses squash merge for clean commit history

## How it works
- Triggers on PR events and CI completion
- Only processes dependabot PRs or branches containing 'auto-merge'
- Waits for all required CI checks to pass
- Automatically squash merges approved PRs

## Test plan
- [x] Workflow YAML syntax is valid
- [x] CI pipeline compatibility verified
- [ ] Will test auto-merge functionality after merge

🤖 Generated with [Claude Code](https://claude.ai/code)